### PR TITLE
Bump nginx from `35e3238` to `b9e1705` in /docker-nginx

### DIFF
--- a/docker-nginx/Dockerfile
+++ b/docker-nginx/Dockerfile
@@ -1,4 +1,4 @@
 # This wraps the upstream nginx image so dependabot can watch it for changes.
 # If https://github.com/dependabot/dependabot-core/issues/390 is addressed, we
 # can just inline this into docker-compose.yml
-FROM nginx:stable-alpine@sha256:35e3238f2f0925a505d5d697df9a9148db9a0c78e89fd2e253919047b3cec824
+FROM nginx:stable-alpine@sha256:b9e1705b69f778dca93cbbbe97d2c2562fb26cac1079cdea4e40d1dad98f14fe


### PR DESCRIPTION
Bumps nginx from `35e3238` to `b9e1705`.

---
updated-dependencies:
- dependency-name: nginx dependency-type: direct:production ...